### PR TITLE
patch profile rather than use temp file.

### DIFF
--- a/tests/test_brain.py
+++ b/tests/test_brain.py
@@ -1,8 +1,5 @@
 """test for brain module."""
-import json
-import os
 import unittest
-from shutil import copyfile
 try:  # py3
     from unittest import mock
 except ImportError:  # py2
@@ -11,10 +8,10 @@ except ImportError:  # py2
 import pytest
 
 
-FULL_TEST_ERR_REASON = 'Not working on full test.'
+NOT_WORKING_ON_FULL_TEST = "Not working on full test."
 
 
-@pytest.mark.xfail(reason=FULL_TEST_ERR_REASON)
+@pytest.mark.xfail(reason=NOT_WORKING_ON_FULL_TEST)
 def test_simple_import():
     """test simple error import.
 
@@ -25,7 +22,7 @@ def test_simple_import():
         from melissa import brain  # NOQA
 
 
-@pytest.mark.xfail(reason=FULL_TEST_ERR_REASON)
+@pytest.mark.xfail(reason=NOT_WORKING_ON_FULL_TEST)
 def test_import_and_mock_populator():
     """test mock profile_populator module when import this module.
 
@@ -37,33 +34,17 @@ def test_import_and_mock_populator():
             from melissa import brain  # NOQA
 
 
-class WithProfileTest(unittest.TestCase):
-    """test case using temp profile."""
-
-    def setUp(self):
-        """setup func."""
-        profile = {
+@mock.patch(
+    'melissa.profile_loader.load_profile',
+    return_value={
             'actions_db_file': ':memory:',
             'modules': 'melissa.actions',
         }
-        self.json_file = 'profile.json'
-        self.bak_file = self.json_file + 'brain-test.bak'
-        if os.path.isfile(self.json_file):
-            self.json_file_exist = True
-            copyfile(self.json_file, self.bak_file)
-        else:
-            self.json_file_exist = False
-        with open(self.json_file, 'w') as f:
-            json.dump(profile, f)
+)
+class WithProfileTest(unittest.TestCase):
+    """test case using temp profile."""
 
-    def tearDown(self):
-        """tear down func."""
-        os.remove(self.json_file)
-        # restore the backup
-        if self.json_file_exist:
-            copyfile(self.bak_file, self.json_file)
-
-    def test_simple_mock_input(self):
+    def test_simple_mock_input(self, m_load_profile):
         """test run til finished with multiple mock."""
         mock_text = mock.Mock()
         with mock.patch(
@@ -79,7 +60,7 @@ class WithProfileTest(unittest.TestCase):
                     assert not mock_acdb.called
                     assert not mock_adb.called
 
-    def test_simple_text_input(self):
+    def test_simple_text_input(self, m_load_profile):
         """test run til finished with multiple mock."""
         mock_text = 'hello world'
         with mock.patch(

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,9 +1,5 @@
 """test profile module."""
-from shutil import copyfile
-import json
 import os
-import random
-import unittest
 try:  # py3
     from unittest import mock
 except ImportError:  # py2
@@ -12,8 +8,7 @@ except ImportError:  # py2
 import pytest
 
 
-xfail_brain_test_mixup = pytest.mark.xfail(
-    reason='Mix up with brain module test.')
+NOT_WORKING_ON_FULL_TEST = "Not working on full test."
 
 
 def profile_file_info():
@@ -28,74 +23,29 @@ def profile_file_info():
     return result
 
 
-class WithoutProfileTest(unittest.TestCase):
-    """test with non existent profile.json file."""
+@pytest.mark.xfail(reason=NOT_WORKING_ON_FULL_TEST)
+def test_import():
+    """test normal import.
 
-    def setUp(self):
-        """set up func."""
-        self.json_file = 'profile.json'
-        self.bak_file = self.json_file + 'profile-test.bak'
-        if os.path.isfile(self.json_file):
-            self.json_file_exist = True
-            copyfile(self.json_file, self.bak_file)
-            os.remove(self.json_file)
-        else:
-            self.json_file_exist = False
+    the error happened because
+    module run the profile populator in testing mode.
+    in profile_populator it need IO where it disable on testing.
+    """
+    with pytest.raises(IOError, message=profile_file_info()):
+        from melissa import profile  # NOQA
 
-    def tearDown(self):
-        """tear down func."""
-        # restore the backup
-        if self.json_file_exist:
-            copyfile(self.bak_file, self.json_file)
 
-    @xfail_brain_test_mixup
-    def test_import(self):
-        """test normal import.
+@pytest.mark.xfail(reason=NOT_WORKING_ON_FULL_TEST)
+def test_import_with_mock_profile_populator():
+    """test importing but mock some obj.
 
-        the error happened because
-        module run the profile populator in testing mode.
-        in profile_populator it need IO where it disable on testing.
-        """
+    the error happened because
+    module run load_profile after run mocked profile_populator func.
+    because it is not exist IOError is raised.
+    """
+    with mock.patch(
+            'melissa.profile_populator.profile_populator') \
+            as mock_profile_populator:
         with pytest.raises(IOError, message=profile_file_info()):
             from melissa import profile  # NOQA
-
-    @xfail_brain_test_mixup
-    def test_import_with_mock_profile_populator(self):
-        """test importing but mock some obj.
-
-        the error happened because
-        module run load_profile after run mocked profile_populator func.
-        because it is not exist IOError is raised.
-        """
-        with mock.patch(
-                'melissa.profile_populator.profile_populator') \
-                as mock_profile_populator:
-            with pytest.raises(IOError, message=profile_file_info()):
-                from melissa import profile  # NOQA
             mock_profile_populator.assert_called_once_with()
-
-    @xfail_brain_test_mixup
-    def test_import_with_temp_file(self):
-        """test importing but create temp file."""
-        with mock.patch('melissa.profile_populator.profile_populator') \
-                as mock_profile_populator:
-            random_int = random.randint(0, 9)
-            json_file = 'profile.json'
-            bak_file = json_file + '.bak'
-            json_file_exist = False
-            try:
-                # backup the file
-                if os.path.isfile(json_file):
-                    json_file_exist = True
-                    copyfile(json_file, bak_file)
-                with open(json_file, 'w') as f:
-                    json.dump(random_int, f)
-
-                from melissa import profile
-                assert profile.data == random_int, profile_file_info()
-            finally:
-                os.remove(json_file)
-                # restore the backup
-                if json_file_exist:
-                    copyfile(bak_file, json_file)
-        assert not mock_profile_populator.called


### PR DESCRIPTION
this not make all xfail disappear. some test, which currently marked as xfail still only working when testing on single module. my guess is , that have something to do with profile module which use global variable.

but it mean future test which use `profile` module  will not have different result in all situation