### PR TITLE
add test for actions plugin.

### DIFF
--- a/tests/test_actions/test_define_subject.py
+++ b/tests/test_actions/test_define_subject.py
@@ -1,0 +1,72 @@
+"""test define_subject modulue."""
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+import pytest
+from wikipedia.exceptions import DisambiguationError
+
+
+@pytest.mark.parametrize('func_input', ['', 'define'])
+def test_multiple_input(func_input):
+    """test with empty speech.
+
+    it raise error because it don't have word 'define'.
+    """
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('melissa.actions.define_subject.tts') as m_tts:
+            from melissa.actions import define_subject
+            if func_input == '':
+                with pytest.raises(ValueError):
+                    define_subject.define_subject('')
+            elif func_input == 'define':
+                define_subject.define_subject(func_input)
+                m_tts.assert_called_once_with(
+                    'define requires subject words')
+
+
+def test_word_define_define():
+    """test word 'define define'."""
+    func_input = 'define define'
+    summary_result = (
+        'A definition is a statement of the meaning of a term (a word, '
+        'phrase, or other set of symbols). Definitions can be classified '
+        'into two large categories, intensional definitions (which try to '
+        'give the essence of a term) and extensional definitions (which '
+        'proceed by listing the objects that a term describes).'
+    )
+    expected_tts_input = (
+        'A definition is a statement of the meaning of a term . '
+        'Definitions can be classified into two large categories, '
+        'intensional definitions and extensional definitions .'
+    )
+    with mock.patch('melissa.actions.define_subject.tts') as m_tts, \
+            mock.patch('melissa.actions.define_subject.wikipedia') \
+            as m_wiki:
+        m_wiki.summary.return_value = summary_result
+        from melissa.actions import define_subject
+        define_subject.define_subject(func_input)
+        m_tts.assert_called_once_with(expected_tts_input)
+        m_wiki.summary.assert_called_once_with('define', sentences=5)
+
+
+def test_raise_wiki_disambiguation_error():
+    """test word 'define define'."""
+    # NOTE: the function still didn't DisambiguationError
+    func_input = 'define define'
+    m_err_title = 'mock_title'
+    m_err_mrt = ['mock_option']  # mrt: may_refer_to
+    with mock.patch('melissa.actions.define_subject.tts') as m_tts, \
+            mock.patch('melissa.actions.define_subject.wikipedia') \
+            as m_wiki:
+        m_wiki.summary.side_effect = \
+            DisambiguationError(
+                m_err_title,
+                m_err_mrt
+            )
+        from melissa.actions import define_subject
+        with pytest.raises(DisambiguationError):
+            define_subject.define_subject(func_input)
+        m_tts.assert_not_called()
+        m_wiki.summary.assert_called_once_with('define', sentences=5)

--- a/tests/test_actions/test_find_iphone.py
+++ b/tests/test_actions/test_find_iphone.py
@@ -1,0 +1,156 @@
+"""test find_iphone modulue."""
+from unittest import TestCase
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+from pyicloud.exceptions import PyiCloudFailedLoginException
+
+
+M_USERNAME = 'm_username'
+M_PASSWORD = 'm_password'
+
+
+def test_find_iphone():
+    """test find_iphone func.
+
+    when given with all mocked dependencies,
+    find_iphone will only give warning
+    about there is no iphone in the given account.
+    """
+    m_text = mock.Mock()
+    with mock.patch('melissa.profile_loader.load_profile'):
+        from melissa import profile
+        profile.data = {
+            'icloud': {'username': M_USERNAME, 'password': M_PASSWORD}}
+        with mock.patch('melissa.actions.find_iphone.PyiCloudService') \
+                as m_pc_service, \
+                mock.patch('melissa.actions.find_iphone.tts') as m_tts:
+            from melissa.actions import find_iphone
+            find_iphone.profile.data = {
+                'icloud': {'username': M_USERNAME, 'password': M_PASSWORD}}
+            # run the func
+            find_iphone.find_iphone(m_text)
+            # testing.
+            m_pc_service.assert_called_once_with(M_USERNAME, M_PASSWORD)
+            m_tts.assert_called_once_with('No iPhones found in your account')
+
+
+class WithProfileTest(TestCase):
+    """test case with profile."""
+
+    def test_find_iphone(self):
+        """test find_iphone func.
+
+        when given with all mocked dependencies,
+        find_iphone will only give warning
+        about there is no iphone in the given account.
+        """
+        m_text = mock.Mock()
+        from melissa.actions import find_iphone
+        with mock.patch('melissa.actions.find_iphone.PyiCloudService') \
+                as m_pc_service, \
+                mock.patch('melissa.actions.find_iphone.tts') as m_tts:
+            # run the func
+            find_iphone.find_iphone(m_text)
+            # testing.
+            m_pc_service.assert_called_once_with(M_USERNAME, M_PASSWORD)
+            m_tts.assert_called_once_with('No iPhones found in your account')
+
+    def test_find_iphone_with_a_phone(self):
+        """test find_iphone func."""
+        m_text = mock.Mock()
+        m_device = mock.Mock()
+        m_device.status.return_value = {'deviceDisplayName': 'iPhone'}
+        from melissa.actions.find_iphone import find_iphone
+        with mock.patch('melissa.actions.find_iphone.PyiCloudService') \
+                as m_pc_service, \
+                mock.patch('melissa.actions.find_iphone.tts') as m_tts:
+            m_pc_service.return_value.devices = [m_device]
+            # run the func
+            find_iphone(m_text)
+            # testing.
+            m_pc_service.assert_called_once_with(M_USERNAME, M_PASSWORD)
+            m_tts.assert_called_once_with(
+                'Sending ring command to the phone now')
+            m_device.status.assert_called_once_with()
+            m_device.play_sound.assert_called_once_with()
+
+    def test_find_iphone_with_2_phones(self):
+        """test find_iphone func."""
+        m_text = mock.Mock()
+        m_device1 = mock.Mock()
+        m_device1.status.return_value = {'deviceDisplayName': 'iPhone'}
+        m_device2 = mock.Mock()
+        m_device2.status.return_value = {'deviceDisplayName': 'iPhone'}
+        from melissa.actions.find_iphone import find_iphone
+        with mock.patch('melissa.actions.find_iphone.PyiCloudService') \
+                as m_pc_service, \
+                mock.patch('melissa.actions.find_iphone.tts') as m_tts:
+            m_pc_service.return_value.devices = [m_device1, m_device2]
+            # run the func
+            find_iphone(m_text)
+            # testing.
+            m_pc_service.assert_called_once_with(M_USERNAME, M_PASSWORD)
+            m_tts.assert_called_with(
+                'Sending ring command to the phone now')
+            m_device1.status.assert_called_once_with()
+            m_device1.play_sound.assert_called_once_with()
+            m_device2.status.assert_called_once_with()
+            m_device2.play_sound.assert_called_once_with()
+
+    def test_find_iphone_raise_failed_login(self):
+        """test find iphone but raise failed login error."""
+        m_text = mock.Mock()
+        from melissa.actions.find_iphone import find_iphone
+        with mock.patch('melissa.actions.find_iphone.PyiCloudService') \
+                as m_pc_service, \
+                mock.patch('melissa.actions.find_iphone.tts') as m_tts:
+            m_pc_service.side_effect = PyiCloudFailedLoginException()
+            # run
+            find_iphone(m_text)
+            # testing
+            m_pc_service.assert_called_once_with(M_USERNAME, M_PASSWORD)
+            m_tts.assert_called_once_with('Invalid Username & Password')
+
+    def test_iphone_battery_raise_failed_login(self):
+        """test find iphone but raise failed login error."""
+        m_text = mock.Mock()
+        from melissa.actions.find_iphone import iphone_battery
+        with mock.patch('melissa.actions.find_iphone.PyiCloudService') \
+                as m_pc_service, \
+                mock.patch('melissa.actions.find_iphone.tts') as m_tts:
+            m_pc_service.side_effect = PyiCloudFailedLoginException()
+            # run
+            iphone_battery(m_text)
+            # testing
+            m_pc_service.assert_called_once_with(M_USERNAME, M_PASSWORD)
+            m_tts.assert_called_once_with('Invalid Username & Password')
+
+    def test_iphone_battery_with_a_phone(self):
+        """test find_iphone func."""
+        m_text = mock.Mock()
+        m_device = mock.Mock()
+        m_battery_level = 0.5
+        expected_percentage = int(float(m_battery_level) * 100)
+        m_tts_expected_arg = '{}percent battery left in m_name'.format(
+            expected_percentage)
+        m_device_name = 'm_name'
+        m_device.status.return_value = {
+            'deviceDisplayName': 'iPhone',
+            'batteryLevel': m_battery_level,
+            'name': m_device_name,
+        }
+        from melissa.actions.find_iphone import iphone_battery
+        with mock.patch('melissa.actions.find_iphone.PyiCloudService') \
+                as m_pc_service, \
+                mock.patch('melissa.actions.find_iphone.tts') as m_tts:
+            m_pc_service.return_value.devices = [m_device]
+            # run the func
+            iphone_battery(m_text)
+            # testing.
+            m_pc_service.assert_called_once_with(M_USERNAME, M_PASSWORD)
+            m_tts.assert_called_once_with(m_tts_expected_arg)
+            assert m_device.status.call_count == 2
+            m_device.status.assert_called_with()

--- a/tests/test_actions/test_general_conversations.py
+++ b/tests/test_actions/test_general_conversations.py
@@ -1,0 +1,115 @@
+"""test general_conversations modulue."""
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+import pytest
+
+
+M_USER_NAME = 'm_user_name'
+M_VA_NAME = 'm_va_name'
+CHOICE_RETVAL = mock.Mock()
+
+
+@pytest.mark.parametrize(
+    'arg, tts_arg',
+    [
+        ('undefined', 'I dont know what that means!'),
+        ('marry_me',
+            'I have been receiving a lot of marriage proposals recently.'),
+        ('love_you', CHOICE_RETVAL),
+        ('are_you_up', 'For you sir, always.'),
+        ('how_are_you', 'I am fine, thank you.'),
+        ('where_born',
+            'I was created by a magician named Tanay, in India, '
+            'the magical land of himalayas.'),
+        ('who_am_i',
+            'You are {}, a brilliant person. '
+            'I love you!'.format(M_USER_NAME)),
+        ('tell_joke', CHOICE_RETVAL),
+        ('how_am_i', CHOICE_RETVAL),
+        ('toss_coin', CHOICE_RETVAL),
+        ('who_are_you', CHOICE_RETVAL),
+    ]
+)
+def test_general_conversation(arg, tts_arg):
+    """test undefined."""
+    m_text = mock.Mock()
+    toss_coin_result = 'heads'
+    va_name = M_VA_NAME
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('melissa.actions.general_conversations.tts') \
+                as m_tts, \
+                mock.patch('melissa.actions.general_conversations.random') \
+                as m_random:
+            # run
+            from melissa.actions import general_conversations
+            if arg == 'toss_coin':
+                general_conversations.random.choice.return_value = \
+                    toss_coin_result
+            elif tts_arg == CHOICE_RETVAL:
+                general_conversations.random.choice.return_value = \
+                    CHOICE_RETVAL
+            if arg == 'who_am_i':
+                general_conversations.profile.data = {
+                    'name': M_USER_NAME}
+            elif arg == 'who_are_you':
+                general_conversations.profile.data = {
+                    'va_name': M_VA_NAME}
+            exec_dict = {
+                'undefined': general_conversations.undefined,
+                'marry_me': general_conversations.marry_me,
+                'love_you': general_conversations.love_you,
+                'are_you_up': general_conversations.are_you_up,
+                'how_are_you': general_conversations.how_are_you,
+                'where_born': general_conversations.where_born,
+                'who_am_i': general_conversations.who_am_i,
+                'tell_joke': general_conversations.tell_joke,
+                'how_am_i': general_conversations.how_am_i,
+                'toss_coin': general_conversations.toss_coin,
+                'who_are_you': general_conversations.who_are_you,
+            }
+            exec_dict[arg](m_text)
+            # test
+            if arg == 'toss_coin':
+                m_tts.assert_called_once_with(
+                    'I just flipped a coin. It shows ' + toss_coin_result
+                )
+            else:
+                m_tts.assert_called_once_with(tts_arg)
+            choice_args_dict = {
+                'love_you': [
+                    'I love you too.',
+                    'You are looking for love in the wrong place.'
+                ],
+                'tell_joke': [
+                    'What happens to a frogs car when it breaks down? '
+                    'It gets toad away.',
+                    'Why was six scared of seven? Because seven ate nine.',
+                    'Why are mountains so funny? Because they are hill areas.',
+                    'Have you ever tried to eat a clock?'
+                    'I hear it is very time consuming.',
+                    'What happened when the wheel was invented? A revolution.',
+                    'What do you call a fake noodle? An impasta!',
+                    'Did you hear about that new broom? '
+                    'It is sweeping the nation!',
+                    'What is heavy forward but not backward? Ton.',
+                    'No, I always forget the punch line.'
+                ],
+                'how_am_i': [
+                    'You are goddamn handsome!',
+                    'My knees go weak when I see you.',
+                    'You are sexy!',
+                    'You look like the kindest person that I have met.'
+                ],
+                'toss_coin': ['heads', 'tails'],
+                'who_are_you':  [
+                    'I am ' + va_name + ', your lovely personal assistant.',
+                    va_name + ', didnt I tell you before?',
+                    'You ask that so many times! I am ' + va_name
+                ]
+            }
+            if arg in choice_args_dict:
+                m_random.choice.assert_called_once_with(
+                    choice_args_dict[arg])

--- a/tests/test_actions/test_horoscope.py
+++ b/tests/test_actions/test_horoscope.py
@@ -1,0 +1,28 @@
+"""test horoscope modulue."""
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+
+def test_tell_horoscope():
+    """test where_born func."""
+    m_text = mock.Mock()
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('melissa.actions.horoscope.tts') \
+                as m_tts, \
+                mock.patch(
+                    'melissa.actions.horoscope.HoroscopeGenerator') \
+                as m_h_gen:
+            # run
+            from melissa.actions.horoscope import tell_horoscope
+            tell_horoscope(m_text)
+            # test
+            m_tts.assert_called_once_with(
+                m_h_gen.format_sentence.return_value)
+            m_h_gen.assert_has_calls = [
+                mock.call.get_sentence(),
+                mock.call.format_sentence(
+                    m_h_gen.get_sentence.return_value
+                )
+            ]

--- a/tests/test_actions/test_imgur_handler.py
+++ b/tests/test_actions/test_imgur_handler.py
@@ -1,0 +1,203 @@
+"""test imgur_handler module."""
+import itertools
+from StringIO import StringIO
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+import pytest
+
+# imgur key
+M_CLIENT_ID = 'm_client_id'
+M_CLIENT_SECRET = 'm_client_secret'
+# memory key
+M_MEMORY_DB = 'm_memory_db'
+# image path key
+M_IMAGES_PATH = 'm_images_path'
+
+
+@pytest.mark.parametrize(
+    'm_ext',
+    ['.tiff', '.png', '.gif', '.jpg']
+)
+def test_img_list_gen(m_ext):
+    """test img_list_gen func."""
+    m_root = mock.Mock()
+    m_file = mock.Mock()
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('melissa.actions.imgur_handler.os') as m_os:
+            # pre run.
+            m_os.walk.return_value = [(m_root, '', [m_file])]
+            m_os.path.splitext.return_value = ['', m_ext]
+            # run
+            from melissa.actions import imgur_handler
+            imgur_handler.profile.data = {
+                'images_path': M_IMAGES_PATH
+            }
+            res = imgur_handler.img_list_gen()
+            # test
+            m_os.assert_has_calls([
+                mock.call.walk(M_IMAGES_PATH),
+                mock.call.path.splitext(m_file),
+                mock.call.path.join(m_root, m_file.lower.return_value)
+            ])
+            assert res == [m_os.path.join.return_value]
+
+
+def test_img_list_gen_incorrect_ext():
+    """test img_list_gen func but with incorrect extension."""
+    m_ext = '.mp3'
+    m_root = mock.Mock()
+    m_file = mock.Mock()
+    with mock.patch('melissa.actions.imgur_handler.os') as m_os:
+        # pre run.
+        m_os.walk.return_value = [(m_root, '', [m_file])]
+        m_os.path.splitext.return_value = ['', m_ext]
+        # run
+        from melissa.actions import imgur_handler
+        res = imgur_handler.img_list_gen()
+        # test
+        assert res == []
+        m_os.assert_has_calls([
+            mock.call.walk(M_IMAGES_PATH),
+            mock.call.path.splitext(m_file)
+        ])
+
+
+@pytest.mark.parametrize(
+    'arg, m_image, gen_return_image',
+    itertools.product(
+        (mock.Mock(), 'upload image', 'upload'),
+        ('image', 'nothing'),
+        (True, False),
+    )
+)
+def test_img_uploader(arg, m_image, gen_return_image):
+    """test image uploader."""
+    m_result_link = 'm_result_link'
+    m_datetime_strftime = '04-11-2016'
+    with mock.patch('melissa.actions.imgur_handler.tts') as m_tts, \
+            mock.patch('melissa.actions.imgur_handler.ImgurClient') \
+            as m_i_client, \
+            mock.patch('sys.stdout', new_callable=StringIO) \
+            as m_stdout, \
+            mock.patch('melissa.actions.imgur_handler.sqlite3') \
+            as m_sqlite3, \
+            mock.patch('melissa.actions.imgur_handler.datetime') \
+            as m_datetime, \
+            mock.patch('melissa.actions.imgur_handler.img_list_gen') \
+            as m_img_list_gen:
+        from melissa.actions import imgur_handler
+        imgur_handler.profile.data = {
+            'imgur': {
+                'client_id': M_CLIENT_ID,
+                'client_secret': M_CLIENT_SECRET,
+            },
+            'memory_db': M_MEMORY_DB,
+        }
+        if isinstance(arg, mock.Mock):
+            # run
+            with pytest.raises(TypeError):
+                imgur_handler.image_uploader(arg)
+            # test
+            arg.assert_has_calls([
+                mock.call.split(),
+                mock.call.split().remove('upload')
+            ])
+
+        elif arg == 'upload':
+            imgur_handler.image_uploader(arg)
+            m_tts.assert_called_once_with(
+                'upload requires a picture name')
+        elif arg == 'upload image':
+            if not gen_return_image:
+                imgur_handler.image_uploader(arg)
+                m_tts.assert_not_called()
+            elif m_image == 'nothing':
+                m_img_list_gen.return_value = [m_image]
+                imgur_handler.image_uploader(arg)
+            elif m_image == 'image':
+                # pre run
+                m_img_list_gen.return_value = [m_image]
+                m_i_client.return_value.upload_from_path.return_value = {
+                    'link': m_result_link}
+                m_datetime.strftime.return_value = m_datetime_strftime
+                # run
+                imgur_handler.image_uploader(arg)
+                # test
+                m_tts.assert_called_once_with(
+                    'Your image has been uploaded')
+                m_i_client.return_value.upload_from_path(
+                    m_image, anon=True, config=None)
+                m_sqlite3.assert_has_calls([
+                    mock.call.connect(M_MEMORY_DB),
+                    mock.call.connect().execute(
+                        (
+                            'INSERT INTO image_uploads '
+                            '(filename, url, upload_date) '
+                            'VALUES (?, ?, ?)'
+                        ),
+                        (
+                            m_image,
+                            m_result_link,
+                            m_datetime_strftime
+                        )
+                    ),
+                    mock.call.connect().commit(),
+                    mock.call.connect().close()
+                ])
+                m_datetime.assert_has_calls([
+                    mock.call.now(),
+                    mock.call.strftime(
+                        m_datetime.now.return_value, '%d-%m-%Y')
+                ])
+                assert m_result_link in m_stdout.getvalue()
+            m_i_client.assert_called_once_with(
+                M_CLIENT_ID,
+                M_CLIENT_SECRET,
+            )
+            m_img_list_gen.assert_called_once_with()
+
+
+def test_show_all_uploads():
+    """test show_all_uploads."""
+    m_text = mock.Mock()
+    exe_retval = [['row0', 'row1', 'row2']]
+    with mock.patch('melissa.actions.imgur_handler.sqlite3') as m_sqlite3, \
+            mock.patch('sys.stdout', new_callable=StringIO) as m_stdout, \
+            mock.patch('melissa.actions.imgur_handler.tts') as m_tts:
+        m_sqlite3.connect.return_value.execute.return_value = exe_retval
+        # run
+        from melissa.actions import imgur_handler
+        imgur_handler.show_all_uploads(m_text)
+        # test
+        assert 'row0: (row1) on row2' in m_stdout.getvalue()
+        m_tts.assert_called_once_with(
+            'Requested data has been printed on your terminal')
+        m_sqlite3.assert_has_calls([
+            mock.call.connect(M_MEMORY_DB),
+            mock.call.connect().execute('SELECT * FROM image_uploads'),
+            mock.call.connect().close()
+        ])
+
+
+def test_img_uploader_with_default_imgur_acc():
+    """test func."""
+    speech_text = mock.Mock()
+    msg = 'upload requires a client id and secret'
+    with mock.patch('sys.stdout', new_callable=StringIO) \
+            as m_stdout, \
+            mock.patch('melissa.actions.imgur_handler.tts') \
+            as m_tts:
+        from melissa.actions import imgur_handler
+        imgur_handler.profile.data = {
+            'imgur': {
+                'client_id': "xxxx",
+                'client_secret': "xxxx",
+            },
+            'memory_db': 'm_memory_db',
+        }
+        imgur_handler.image_uploader(speech_text)
+        assert msg in m_stdout.getvalue()
+        m_tts.assert_called_once_with(msg)

--- a/tests/test_actions/test_ip_address.py
+++ b/tests/test_actions/test_ip_address.py
@@ -1,0 +1,51 @@
+"""test ip_address module."""
+import itertools
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    'ifs_retval, setdefault_retval',
+    itertools.product(
+        ['lo', 'eth0'],
+        [
+            [{'addr': '127.0.0.1'}, {'addr': None}],
+            [{'addr': '127.0.0.1'}]
+        ]
+    )
+)
+def test_ip_address(ifs_retval, setdefault_retval):
+    """test ip_address."""
+    m_text = mock.Mock()
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('melissa.actions.ip_address.tts') as m_tts, \
+                mock.patch('melissa.actions.ip_address.AF_INET') \
+                as m_af_inet, \
+                mock.patch('melissa.actions.ip_address.ifaddresses') \
+                as m_ifa, \
+                mock.patch('melissa.actions.ip_address.interfaces') as m_ifs:
+            m_ifs.return_value = [ifs_retval]
+            m_ifa.return_value.setdefault.return_value = setdefault_retval
+            from melissa.actions import ip_address
+            ip_address.ip_address(m_text)
+            if ifs_retval == ['lo']:
+                m_tts.assert_has_calls([
+                    mock.call('Here are my available I.P. addresses.'),
+                    mock.call('Those are all my I.P. addresses.')
+                ])
+            elif ifs_retval == ['eth0']:
+                m_tts.assert_has_calls([
+                    mock.call('Here are my available I.P. addresses.'),
+                    mock.call(
+                        'interface: eth0, I.P. Address : '
+                        '127 dot 0 dot 0 dot 1'),
+                    mock.call('Those are all my I.P. addresses.')
+                ])
+            m_ifa.assert_has_calls([
+                mock.call(ifs_retval),
+                mock.call().setdefault(m_af_inet, [{'addr': None}])
+            ])

--- a/tests/test_actions/test_lighting.py
+++ b/tests/test_actions/test_lighting.py
@@ -1,0 +1,42 @@
+"""test module."""
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    'arg, blink1_arg, tts_arg',
+    [
+        ('very_dark', '--white', 'Better now?'),
+        ('feeling_angry', '--cyan', 'Calm down dear!'),
+        ('feeling_creative', '--magenta', 'So good to hear that!'),
+        ('feeling_lazy', '--yellow', 'Rise and shine dear!'),
+        ('turn_off', '--off', None),
+    ]
+)
+def test_lighting(arg, blink1_arg, tts_arg):
+    """test func."""
+    m_text = mock.Mock()
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('melissa.actions.lighting.subprocess') \
+                as m_subprocess, \
+                mock.patch('melissa.actions.lighting.tts') \
+                as m_tts:
+            from melissa.actions import lighting
+            if arg == 'very_dark':
+                lighting.very_dark(m_text)
+            elif arg == 'feeling_angry':
+                lighting.feeling_angry(m_text)
+            elif arg == 'feeling_creative':
+                lighting.feeling_creative(m_text)
+            elif arg == 'feeling_lazy':
+                lighting.feeling_lazy(m_text)
+            elif arg == 'turn_off':
+                lighting.turn_off(m_text)
+            m_subprocess.call.assert_called_once_with(
+                ['blink1-tool', blink1_arg])
+            if tts_arg is not None:
+                m_tts.assert_called_once_with(tts_arg)

--- a/tests/test_actions/test_notes.py
+++ b/tests/test_actions/test_notes.py
@@ -1,0 +1,59 @@
+"""test module."""
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+
+M_MEMORY_DB = 'm_memory_db'
+
+
+def test_show_all_notes():
+    """test func."""
+    row0 = mock.Mock()
+    m_text = mock.Mock()
+    with mock.patch('melissa.profile_loader.load_profile'):
+        from melissa import profile
+        profile.data = {'memory_db': M_MEMORY_DB}
+        with mock.patch('melissa.actions.notes.sqlite3') as m_sqlite3, \
+                mock.patch('melissa.actions.notes.tts') as m_tts:
+            m_sqlite3.connect.return_value.execute.return_value = [[row0]]
+            # run
+            from melissa.actions import notes
+            notes.show_all_notes(m_text)
+            # test
+            m_tts.assert_has_calls([
+                mock.call('Your notes are as follows:'),
+                mock.call(row0)
+            ])
+            m_sqlite3.assert_has_calls([
+                mock.call.connect(M_MEMORY_DB),
+                mock.call.connect().execute('SELECT notes FROM notes'),
+                mock.call.connect().close()
+            ])
+
+
+def test_note_something():
+    """test func."""
+    m_text = "note something"
+    with mock.patch('melissa.actions.notes.sqlite3') as m_sqlite3, \
+            mock.patch('melissa.actions.notes.datetime') as m_datetime, \
+            mock.patch('melissa.actions.notes.tts') as m_tts:
+        # run
+        from melissa.actions import notes
+        notes.note_something(m_text)
+        # test
+        m_sqlite3.assert_has_calls([
+            mock.call.connect(M_MEMORY_DB),
+            mock.call.connect().execute(
+                'INSERT INTO notes (notes, notes_date) VALUES (?, ?)',
+                ('something', m_datetime.strftime.return_value)
+            ),
+            mock.call.connect().commit(),
+            mock.call.connect().close()
+        ])
+        m_tts.assert_called_once_with('Your note has been saved.')
+        m_datetime.assert_has_calls([
+            mock.call.now(),
+            mock.call.strftime(m_datetime.now.return_value, '%d-%m-%Y')
+        ])

--- a/tests/test_actions/test_play_music.py
+++ b/tests/test_actions/test_play_music.py
@@ -1,0 +1,200 @@
+"""test module."""
+import itertools
+from StringIO import StringIO
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+import pytest
+
+
+def test_music_player():
+    """test fun."""
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('melissa.actions.play_music.os') as m_os:
+            from melissa.actions.play_music import music_player
+            res = music_player(['item0', 'item1'])
+            m_os.system.assert_called_once_with("item0 'item1'")
+            assert res == m_os.system.return_value
+
+
+@pytest.mark.parametrize('raise_index_error', [True, False])
+def test_play_random(raise_index_error):
+    """test func."""
+    m_text = mock.Mock()
+    m_file = 'm_file'
+    choice_retval = ['', m_file]
+    m_ext = 'm_ext'
+    split_ext_retval = ['', m_ext]
+    index_err_msg = 'error'
+    with mock.patch('melissa.actions.play_music.mp3gen') as m_mp3gen, \
+            mock.patch('melissa.actions.play_music.os') as m_os, \
+            mock.patch('melissa.actions.play_music.tts') as m_tts, \
+            mock.patch('sys.stdout', new_callable=StringIO) as m_stdout, \
+            mock.patch('melissa.actions.play_music.random') as m_random, \
+            mock.patch('melissa.actions.play_music.music_player') as m_mp:
+        # prepare
+        m_random.choice.return_value = choice_retval
+        if raise_index_error:
+            m_os.path.splitext.side_effect = IndexError(index_err_msg)
+        else:
+            m_os.path.splitext.return_value = split_ext_retval
+        from melissa.actions.play_music import play_random
+        # run
+        play_random(m_text)
+        # test
+        m_mp3gen.assert_called_once_with()
+        m_os.path.splitext.assert_called_once_with(m_file)
+        m_random.choice.assert_called_once_with(None)
+        if not raise_index_error:
+            m_tts.assert_called_once_with('Now playing: ')
+            assert m_stdout.getvalue() == ''
+            m_mp.assert_called_once_with(choice_retval)
+        else:
+            m_tts.assert_called_once_with('No music files found.')
+            assert 'No music files found: {}'.format(index_err_msg) \
+                in m_stdout.getvalue()
+            m_mp.assert_not_called()
+
+
+def test_play_specific_music():
+    """test func."""
+    msg = 'm_music'
+    speech_text = 'play {}'.format(msg)
+    music_listing_item = ['', msg]
+    with mock.patch('melissa.actions.play_music.mp3gen') \
+            as m_mp3gen, \
+            mock.patch('melissa.actions.play_music.music_player') \
+            as m_music_player:
+        # run
+        from melissa.actions import play_music
+        play_music.music_listing = [music_listing_item]
+        play_music.play_specific_music(speech_text)
+        # tests
+        m_mp3gen.assert_called_once_with()
+        m_music_player.assert_called_once_with(music_listing_item)
+
+
+@pytest.mark.parametrize(
+    'platform, m_file_ext',
+    list(itertools.product(
+        ['darwin', 'win32', 'linux', 'random'],
+        ['.wav', '.flac', 'ogg', '.mp3', '.mp4']
+    ))
+)
+def test_mp3gen(platform, m_file_ext):
+    """test func."""
+    m_music_path = 'm_music_path'
+    splitext_retval = ['filename', m_file_ext]
+    m_root = mock.Mock()
+    m_file = mock.Mock()
+    walk_retval = [(m_root, None, [m_file])]
+    with mock.patch('melissa.actions.play_music.sys') \
+            as m_sys, \
+            mock.patch('sys.stdout', new_callable=StringIO) \
+            as m_stdout, \
+            mock.patch('melissa.actions.play_music.os') \
+            as m_os:
+        # pre run
+        m_os.path.splitext.return_value = splitext_retval
+        m_os.walk.return_value = walk_retval
+        m_sys.platform = platform
+        # run
+        from melissa.actions import play_music
+        play_music.profile.data = {'music_path': m_music_path}
+        play_music.music_listing = None
+        play_music.mp3gen()
+        # test
+        cmd = None
+        if platform in ('win32', 'linux') and m_file_ext == '.mp3':
+            cmd = 'mpg123'
+        elif platform in ('win32', 'linux') and \
+                m_file_ext in play_music.sox_file_types:
+            cmd = 'play'
+        elif platform == 'darwin' and m_file_ext == '.mp3':
+            cmd = 'afplay'
+        if platform == 'random':
+            assert \
+                'Music only enabled on darwin, win32, and linux.' in \
+                m_stdout.getvalue()
+            m_file.assert_not_called()
+            assert not m_os.mock_calls
+        else:
+            if m_file_ext == '.mp3':
+                m_os.assert_has_calls([
+                    mock.call.walk(m_music_path),
+                    mock.call.path.splitext(m_file),
+                    mock.call.path.join(m_root, m_file.lower.return_value),
+                ])
+            elif m_file_ext in play_music.sox_file_types:
+                m_os.assert_has_calls([
+                    mock.call.walk(m_music_path),
+                    mock.call.path.splitext(m_file),
+                    mock.call.path.splitext(m_file)
+                ])
+            if cmd is not None:
+                assert play_music.music_listing == [[
+                    cmd, m_os.path.join.return_value]]
+                m_file.lower.assert_called_once_with()
+            else:
+                assert not m_file.mock_calls
+                m_os.assert_has_calls([
+                    mock.call.walk(m_music_path),
+                    mock.call.path.splitext(m_file),
+                    mock.call.path.splitext(m_file)
+                ])
+
+
+def test_mp3gen_with_non_empty_music_listing():
+    """test func."""
+    music_item = mock.Mock()
+    with mock.patch('melissa.actions.play_music.sys') \
+            as m_sys, \
+            mock.patch('sys.stdout', new_callable=StringIO) \
+            as m_stdout, \
+            mock.patch('melissa.actions.play_music.os') \
+            as m_os:
+        # run
+        from melissa.actions import play_music
+        play_music.music_listing = [[music_item]]
+        play_music.mp3gen()
+        assert play_music.music_listing == [[music_item]]
+        assert not m_sys.mock_calls
+        assert '' == m_stdout.getvalue()
+        assert not m_os.mock_calls
+
+
+@pytest.mark.parametrize('raise_index_error', [True, False])
+def test_play_shuffle(raise_index_error):
+    """test func."""
+    music_item = mock.Mock()
+    m_text = mock.Mock()
+    m_index = 0
+    with mock.patch('melissa.actions.play_music.mp3gen') \
+            as m_mp3gen, \
+            mock.patch('sys.stdout', new_callable=StringIO) \
+            as m_stdout, \
+            mock.patch('melissa.actions.play_music.tts') \
+            as m_tts, \
+            mock.patch('melissa.actions.play_music.music_player') \
+            as m_music_player, \
+            mock.patch('melissa.actions.play_music.random') \
+            as m_random:
+        # pre run
+        if raise_index_error:
+            m_music_player.side_effect = IndexError(m_index)
+        # run
+        from melissa.actions import play_music
+        play_music.music_listing = [music_item]
+        play_music.play_shuffle(m_text)
+        # tests
+        m_mp3gen.assert_called_once_with()
+        m_random.shuffle.assert_called_once_with([music_item])
+        if not raise_index_error:
+            m_music_player.assert_called_once_with(music_item)
+            m_tts.assert_not_called()
+            assert '' == m_stdout.getvalue()
+        else:
+            m_tts.assert_called_once_with('No music files found.')
+            assert 'No music files found: 0' in m_stdout.getvalue()

--- a/tests/test_actions/test_repeat.py
+++ b/tests/test_actions/test_repeat.py
@@ -1,0 +1,15 @@
+"""test module."""
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+
+def test_repeat_text():
+    """test func."""
+    m_text = 'repeat this text'
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('melissa.actions.repeat.tts') as m_tts:
+            from melissa.actions import repeat
+            repeat.repeat_text(m_text)
+            m_tts.assert_called_once_with('this text')

--- a/tests/test_actions/test_self_destruct.py
+++ b/tests/test_actions/test_self_destruct.py
@@ -1,0 +1,24 @@
+"""test module."""
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+import pytest
+
+
+def test_self_destruct():
+    """test func."""
+    m_text = ''
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('melissa.actions.self_destruct.tts') as m_tts, \
+                mock.patch('melissa.actions.self_destruct.subprocess') \
+                as m_subprocess:
+            from melissa.actions import self_destruct
+            with pytest.raises(SystemExit):
+                self_destruct.self_destruct(m_text)
+            m_subprocess.call.assert_called_once_with(
+                ['sudo', 'rm', '-r', '../Melissa-Core']
+            )
+            m_tts.assert_called_once_with(
+                'Self destruction mode engaged, over and out.')

--- a/tests/test_actions/test_sleep.py
+++ b/tests/test_actions/test_sleep.py
@@ -1,0 +1,39 @@
+"""test module."""
+from StringIO import StringIO
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+import pytest
+
+
+@pytest.mark.parametrize('hotword_detection', ['on', 'off'])
+def test_go_to_sleep(hotword_detection):
+    """test func."""
+    m_text = ''
+    print_args = [
+        '\nListening for Keyword...',
+        'Press Ctrl+C to exit\n'
+    ]
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('melissa.actions.sleep.tts') as m_tts, \
+                mock.patch('sys.stdout', new_callable=StringIO) \
+                as m_stdout, \
+                mock.patch('melissa.actions.sleep.random') \
+                as m_random:
+            # run
+            from melissa.actions import sleep
+            sleep.profile.data = {'hotword_detection': hotword_detection}
+            with pytest.raises(SystemExit):
+                sleep.go_to_sleep(m_text)
+            # test
+            m_stdout_value = m_stdout.getvalue()
+            if hotword_detection == 'on':
+                for arg in print_args:
+                    assert arg in m_stdout_value
+            else:
+                assert not m_stdout_value
+            m_tts.assert_called_once_with(m_random.choice.return_value)
+            m_random.choice.assert_called_once_with(
+                ['See you later!', "Just call my name and I'll be there!"])

--- a/tests/test_actions/test_spelling.py
+++ b/tests/test_actions/test_spelling.py
@@ -1,0 +1,19 @@
+"""test module."""
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+
+def test_spell_text():
+    """test func."""
+    m_text = mock.Mock()
+    sub_text = 'm_sub_text'
+    expected_tts_arg = 'm _ s u b _ t e x t'
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('melissa.actions.spelling.tts') as m_tts:
+            from melissa.actions import spelling
+            m_text.split.return_value = [None, sub_text]
+            spelling.spell_text(m_text)
+            m_text.split.assert_called_once_with(' ', 1)
+            m_tts.assert_called_once_with(expected_tts_arg)

--- a/tests/test_actions/test_system_status.py
+++ b/tests/test_actions/test_system_status.py
@@ -1,0 +1,86 @@
+"""test module."""
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+
+def test_system_status():
+    """test func."""
+    m_text = mock.Mock()
+    m_os = mock.Mock()
+    m_name = mock.Mock()
+    m_version = mock.Mock()
+    m_version_subinfo = mock.Mock()
+    m_memory_percent = mock.Mock()
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('melissa.actions.system_status.platform') \
+                as m_platform, \
+                mock.patch('melissa.actions.system_status.psutil') \
+                as m_psutil, \
+                mock.patch('melissa.actions.system_status.tts') \
+                as m_tts:
+            # pre run
+            m_platform.uname.return_value = [
+                m_os, m_name, m_version, None, None, None]
+            m_version.split.return_value = [m_version_subinfo]
+            m_psutil.virtual_memory.return_value = [
+                None, None, m_memory_percent]
+            # run
+            from melissa.actions import system_status
+            system_status.system_status(m_text)
+            # test
+            m_tts.assert_called_once_with(
+                "I am currently running on {} version {}. "
+                "This system is named {} and has {} CPU cores. "
+                "Current CPU utilization is {} percent. "
+                "Current memory utilization is {} percent. "
+                "Current disk utilization is {} percent. ".format(
+                    m_os, m_version_subinfo, m_name,
+                    m_psutil.cpu_count.return_value,
+                    m_psutil.cpu_percent.return_value,
+                    m_memory_percent,
+                    m_psutil.disk_usage.return_value.percent,
+                )
+            )
+            m_platform.uname.assert_called_once_with()
+            m_psutil.assert_has_calls([
+                mock.call.cpu_count(),
+                mock.call.cpu_percent(),
+                mock.call.virtual_memory(),
+                mock.call.disk_usage('/'),
+            ])
+            m_version.split.assert_called_once_with('-')
+
+
+def test_system_uptime():
+    """test func."""
+    m_text = mock.Mock()
+    strftime_retval = 'Sunday 06. November 2016'
+    m_boot_time = mock.Mock()
+    with mock.patch('melissa.actions.system_status.datetime') \
+            as m_datetime, \
+            mock.patch('melissa.actions.system_status.psutil') \
+            as m_psutil, \
+            mock.patch('melissa.actions.system_status.tts') \
+            as m_tts:
+        # pre run
+        m_boot_time.strftime.return_value = strftime_retval
+        m_datetime.datetime.fromtimestamp.return_value = m_boot_time
+        # run
+        from melissa.actions import system_status
+        system_status.system_uptime(m_text)
+        # test
+        m_datetime.assert_has_calls([
+            mock.call.datetime.fromtimestamp(
+                m_psutil.boot_time.return_value),
+            mock.call.datetime.fromtimestamp().strftime(
+                '%A %d. %B %Y'),
+        ])
+        m_boot_time.strftime.assert_called_once_with("%A %d. %B %Y")
+        m_psutil.boot_time.assert_called_once_with()
+        m_tts.assert_called_once_with(
+            'System has been running since {}'.format(
+                strftime_retval
+            )
+        )

--- a/tests/test_actions/test_tell_time.py
+++ b/tests/test_actions/test_tell_time.py
@@ -1,0 +1,43 @@
+"""test module."""
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    'arg, strftime_expected_format',
+    [
+        ('date', '%m/%d/%Y'),
+        ('day', '%A'),
+        ('time', '%H:%M:%S'),
+    ]
+)
+def test_tell_time(arg, strftime_expected_format):
+    """test func."""
+    strftime_retval = 'strftime_retval'
+    m_text = mock.Mock()
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('melissa.actions.tell_time.tts') \
+                as m_tts, \
+                mock.patch('melissa.actions.tell_time.datetime') \
+                as m_datetime:
+            m_datetime.strftime.return_value = strftime_retval
+            from melissa.actions import tell_time
+            if arg == 'date':
+                tell_time.what_is_date(m_text)
+            elif arg == 'time':
+                tell_time.what_is_time(m_text)
+            elif arg == 'day':
+                tell_time.what_is_day(m_text)
+            m_tts.assert_called_once_with(
+                'The {} is {}'.format(arg, strftime_retval))
+            m_datetime.assert_has_calls([
+                mock.call.now(),
+                mock.call.strftime(
+                    m_datetime.now.return_value,
+                    strftime_expected_format
+                )
+            ])

--- a/tests/test_actions/test_twitter_interaction.py
+++ b/tests/test_actions/test_twitter_interaction.py
@@ -1,0 +1,67 @@
+"""test module."""
+from StringIO import StringIO
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+import pytest
+
+
+@pytest.mark.parametrize('use_default_profile', [True, False])
+def test_post_tweet(use_default_profile):
+    """test func."""
+    def_val = 'xxxx'
+    default_profile = {
+        'twitter': {
+            'consumer_key': def_val,
+            'consumer_secret': def_val,
+            'access_token': def_val,
+            'access_token_secret': def_val
+        }
+    }
+    new_profile = {
+        'twitter': {
+            'consumer_key': 'consumer_key',
+            'consumer_secret': 'consumer_secret',
+            'access_token': 'access_token',
+            'access_token_secret': 'access_token_secret'
+        }
+    }
+    def_profile_error_msg = (
+        'Twitter requires a consumer key and secret, '
+        'and an access token and token secret.')
+    m_text = mock.Mock()
+    words_of_message = ['tweet', 'some', 'message']
+    exp_cleaned_message = 'Some message'
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('sys.stdout', new_callable=StringIO) \
+                as m_stdout, \
+                mock.patch('melissa.actions.twitter_interaction.tweepy') \
+                as m_tweepy, \
+                mock.patch('melissa.actions.twitter_interaction.tts') \
+                as m_tts:
+            # pre run
+            from melissa.actions import twitter_interaction
+            if use_default_profile:
+                twitter_interaction.profile.data = default_profile
+            else:
+                twitter_interaction.profile.data = new_profile
+                m_text.split.return_value = words_of_message
+            # run
+            twitter_interaction.post_tweet(m_text)
+            # test
+            if use_default_profile:
+                m_tts.assert_called_once_with(def_profile_error_msg)
+                assert def_profile_error_msg in m_stdout.getvalue()
+            else:
+                m_tts.assert_called_once_with('Your tweet has been posted')
+                assert not m_stdout.getvalue()
+                m_text.split.assert_called_once_with()
+                m_tweepy.assert_has_calls([
+                    mock.call.OAuthHandler('consumer_key', 'consumer_secret'),
+                    mock.call.OAuthHandler().set_access_token(
+                        'access_token', 'access_token_secret'),
+                    mock.call.API(m_tweepy.OAuthHandler.return_value),
+                    mock.call.API().update_status(status=exp_cleaned_message)
+                ])

--- a/tests/test_actions/test_weather.py
+++ b/tests/test_actions/test_weather.py
@@ -1,0 +1,55 @@
+"""test module."""
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    'degrees, expected_temp',
+    [
+        ('fahrenheit', 77),
+        ('celcius', 25)
+    ]
+)
+def test_post_tweet(degrees, expected_temp):
+    """test func."""
+    m_text = mock.Mock()
+    actual_temp_in_celcius = 25
+    city_name = 'city_name'
+    city_code = mock.Mock()
+    weather_cond = 'cloudy'
+    profile_data = {
+        'city_name': city_name,
+        'city_code': city_code,
+        'degrees': degrees,
+    }
+    weather_result = {
+        'current_conditions': {
+            'temperature': actual_temp_in_celcius,
+            'text': weather_cond
+        }
+    }
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('melissa.actions.weather.tts') \
+                as m_tts, \
+                mock.patch('melissa.actions.weather.pywapi') \
+                as m_pywapi:
+            # pre run
+            from melissa.actions import weather
+            weather.profile.data = profile_data
+            m_pywapi.get_weather_from_weather_com.return_value = weather_result
+            # run
+            weather.weather(m_text)
+            # test
+            m_tts.assert_called_once_with(
+                'Weather.com says: It is {} and {}degrees {} now '
+                'in {}'.format(
+                    weather_cond, float(expected_temp), degrees, city_name
+                )
+            )
+            m_pywapi.get_weather_from_weather_com.assert_called_once_with(
+                city_code
+            )


### PR DESCRIPTION
- mock profile for every test.
- pass flake8.
- test for define_subject func.
- test for find_iphone module.
- test for horoscope.
- test for repeat module.
- test general_conversations WIP.
- test imgur handler.
- test ip address module.
- test lighting.
- test note module.
- test play_music module.
- test self destruct.
- test sleep.
- test spelling.
- test system status.
- test tell time.
- test twitter.
- test weather module.
- use parametrize and better patch.
- not using conftest

for #67 

notes:

- business reader can't be tested because most of the work is using global variable.
- one of the module which using wiki module can't catch the error.