### PR TITLE
test start module.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ install:
   - pip install -r ./requirements-dev.txt
 script:
   - flake8
-  - "python -m pytest --cov=melissa --cov-config=.coveragerc"
+  - "python -m pytest 
+     --cov=melissa \
+     --cov=start \
+     --cov-config=.coveragerc"
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/start.py
+++ b/start.py
@@ -26,4 +26,5 @@ def main():
         else:
             query(text)
 
-main()
+if __name__ == "__main__":
+    main()

--- a/tests/test_start/test_start.py
+++ b/tests/test_start/test_start.py
@@ -1,0 +1,85 @@
+"""test start module."""
+from itertools import product
+try:  # py3
+    from unittest import mock
+except ImportError:  # py2
+    import mock
+
+import pytest
+
+
+M_TEXT = 'query_text'
+NOT_WORKING_ON_FULL_TEST = "Not working on full test."
+
+
+@pytest.mark.xfail(reason=NOT_WORKING_ON_FULL_TEST)
+def test_import():
+    """test import.
+
+    error is raised
+    because profile populator run and raise error when testing.
+    """
+    with pytest.raises(IOError):
+        from start import main  # NOQA
+
+
+@pytest.mark.xfail(reason=NOT_WORKING_ON_FULL_TEST)
+def test_mock_pp():
+    """test with mocked populator."""
+    with mock.patch('melissa.profile_populator.profile_populator'):
+        with pytest.raises(IOError):
+            from start import main  # NOQA
+
+
+@pytest.mark.xfail(reason=NOT_WORKING_ON_FULL_TEST)
+def test_import_module():
+    """test simple import."""
+    with pytest.raises(IOError):
+        import start  # NOQA
+
+
+@pytest.mark.parametrize(
+    'platform, m_stt_side_effect',
+    product(
+        ['linux', 'win32', 'darwin', 'random'],
+        [
+            KeyboardInterrupt,
+            [None, KeyboardInterrupt],
+            [M_TEXT, KeyboardInterrupt],
+        ]
+    )
+)
+def test_run_main(platform, m_stt_side_effect):
+    """test run main func."""
+    with mock.patch('melissa.profile_loader.load_profile'):
+        with mock.patch('start.tts') as m_tts, \
+                mock.patch('start.subprocess') as m_subprocess, \
+                mock.patch('start.stt') as m_stt, \
+                mock.patch('start.load_profile') as m_load_profile, \
+                mock.patch('start.sys') as m_sys, \
+                mock.patch('start.query') as m_query:
+            # pre run
+            m_stt.side_effect = m_stt_side_effect
+            m_sys.platform = platform
+            # run
+            import start
+            with pytest.raises(KeyboardInterrupt):
+                start.main()
+            # test
+            m_load_profile.assert_called_once_with(True)
+            if platform.startswith('linux') or platform == 'win32':
+                m_subprocess.call.assert_called_with(
+                    ['mpg123', 'data/snowboy_resources/ding.wav'])
+            elif platform == 'darwin':
+                m_subprocess.call.assert_called_with(
+                    ['afplay', 'data/snowboy_resources/ding.wav'])
+            else:
+                m_subprocess.call.assert_not_called()
+            if m_stt_side_effect != KeyboardInterrupt:
+                if m_stt_side_effect[0] == M_TEXT:
+                    m_query.assert_called_once_with(M_TEXT)
+                assert m_stt.call_count == 2
+            else:
+                m_query.assert_not_called()
+                m_stt.assert_called_once_with()
+            m_tts.assert_called()


### PR DESCRIPTION
- add test for start module.
- fix profile patch on for easier testing on full test.
- move to subfolder

the test have to be moved to subfolder, so it can run on full test, without make other tests fail.

~~e: not yet finished. have to change coverage setting to include `start` module~~

e2: finished.  for #67 

- travis setting is changed so start file can also be counted on coverage. it require simple changes to travis setting. there is a way to change it using config file (with `include` key) but i can't make it working.
 - travis setting still include old setting (`--cov-config=.coveragerc`). but i keep it to focus only on changing the included test module.
- the `start` file also changed for easier testing.